### PR TITLE
Feature/plugin teardown hook

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ function getClientClass(apiClass) {
             // initiate connection to the broker
             this.conn = this.connect()
                 .then((conn) => {
-                    this.aborted.then(this.close);
+                    this.aborted.then(this.close.bind(this));
                     return conn;
                 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,8 @@ const { tap } = require('./utils');
 // Utilities
 //
 
+const noop = () => {};
+
 // create an observable subject.
 const createSubject = () => {
     let broadcast, subscribe = new Promise((resolve) => broadcast = resolve);
@@ -66,7 +68,8 @@ function getClientClass(apiClass) {
             logger,
             abort,
             _assert,
-            _asserted
+            _asserted,
+            _onClose = noop
         }) {
             super(null, {
                 logger,
@@ -79,7 +82,8 @@ function getClientClass(apiClass) {
             defineProperties(this, {
                 ready,
                 aborted,
-                factories
+                factories,
+                _onClose
             });
         }
 
@@ -96,6 +100,7 @@ function getClientClass(apiClass) {
             // initiate connection to the broker
             this.conn = this.connect()
                 .then((conn) => {
+                    conn.on('close', this._onClose);
                     this.aborted.then(this.close.bind(this));
                     return conn;
                 });
@@ -118,7 +123,8 @@ function getClientClass(apiClass) {
         }
 
         close() {
-            return this.conn.then((conn) => conn.close())
+            return this.conn
+                .then((conn) => conn.close())
                 .catch((err) => {
                     this.logger.warn('[AMQP] An error occurred when closing a connection', err.message);
                 });
@@ -140,14 +146,9 @@ const Client = function(url, options = {}) {
         ...opts
     } = options;
 
-    // observable to be fired when aborting all operations and tearing down
-    const { subscribe: cancelled, broadcast: abort } = createSubject();
-
     // context to be passed to plugins. should be smallest
     const context = {
-        logger,
-        cancelled,
-        cancel: abort
+        logger
     };
 
     // factories of core method/classes. decorated by plugins
@@ -164,6 +165,9 @@ const Client = function(url, options = {}) {
             context, ContextChannel, Scopes.API, plugins)
     };
 
+    // observable to be fired when aborting all operations and tearing down
+    const { subscribe: aborted, broadcast: abort } = createSubject();
+
     const { subscribe: _asserted, extend: _assert, broadcast: ready } = createExtendable();
 
     // extended API
@@ -172,12 +176,14 @@ const Client = function(url, options = {}) {
 
     return new Client({
         ready,
-        aborted: cancelled,
+        aborted,
         factories,
         logger,
         abort,
         _assert,
-        _asserted
+        _asserted,
+        _onClose: () => plugins.forEach((plugin) =>
+            typeof plugin.destroy === 'function' && plugin.destroy())
     });
 
 };

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -15,4 +15,6 @@ module.exports = class Plugin {
         else throw new Error(`Plugin not implemented for scope '${scope}'`);
     }
 
+    destroy() {}
+
 };

--- a/plugins/conn-retry.js
+++ b/plugins/conn-retry.js
@@ -7,54 +7,54 @@ const createBackoff = ({
     base = 2
 }) => (c) => Math.min(max, Math.pow(base, c) * min);
 
-const retry = ({ retries, backoff, logger, cancelled }) => {
-    return (connect) => {
-        const retryable = (c, ...args) => {
-            if (0 < c) logger.debug('[AMQP:conn-retry] Retrying to connect...');
-
-            return connect(...args)
-                .catch((err) => {
-                    if (c + 1 >= retries) throw err;
-
-                    const wait = backoff(c);
-                    logger.warn(
-                        `[AMQP:conn-retry] Connection failed. Retrying in ${wait}ms...`,
-                        err.message);
-
-                    return new Promise((resolve, reject) => {
-                        const id = setTimeout(() =>
-                            retryable(c + 1, ...args).then(resolve).catch(reject), wait);
-
-                        cancelled.then(() => clearTimeout(id));
-                    });
-                });
-        };
-
-        return retryable.bind(null, 0);
-    };
-};
-
 module.exports = class extends Plugin {
 
     constructor(options = {}) {
         super();
+
         this.options = options;
+        this.timeouts = [];
+
+        const attempt = ({ logger }) => {
+            const { retries = 5 } = this.options;
+            const backoff = createBackoff(this.options);
+
+            return this.retry({ retries, backoff, logger });
+        };
+
         this.wrappers = {
-            [CONNECTION]: this.attemptConnection.bind(this)
+            [CONNECTION]: attempt
         };
     }
 
-    attemptConnection({ logger, cancelled }) {
-        cancelled.then((reason) => {
-            logger.warn(
-                '[AMQP:conn-retry] Retries will be cancelled. Reason:',
-                reason && reason.message);
-        });
+    retry({ retries, backoff, logger }) {
+        return (connect) => {
+            const retryable = (c, ...args) => {
+                if (0 < c) logger.debug('[AMQP:conn-retry] Retrying to connect...');
 
-        const { retries = 5 } = this.options;
-        const backoff = createBackoff(this.options);
+                return connect(...args)
+                    .catch((err) => {
+                        if (c + 1 >= retries) throw err;
 
-        return retry({ retries, backoff, logger, cancelled });
+                        const wait = backoff(c);
+                        logger.warn(
+                            `[AMQP:conn-retry] Connection failed. Retrying in ${wait}ms...`,
+                            err.message);
+
+                        return new Promise((resolve, reject) => {
+                            const timer = setTimeout(() =>
+                                retryable(c + 1, ...args).then(resolve).catch(reject), wait);
+                            this.timeouts.push(timer);
+                        });
+                    });
+            };
+
+            return retryable.bind(null, 0);
+        };
+    }
+
+    destroy() {
+        this.timeouts.forEach(timer => clearTimeout(timer));
     }
 
 };


### PR DESCRIPTION
Use `Client.close()` as global cancellation, so that the plugins can respond to it by destroying their resources, like timers and promises.
It eliminates the need of passing around the cancellation context across plugins.